### PR TITLE
Fix a bug of merge permission

### DIFF
--- a/pkg/providers/merge/event.go
+++ b/pkg/providers/merge/event.go
@@ -54,7 +54,7 @@ func (m *merge) havePermission(username string, pr *github.PullRequest) bool {
 		}
 	}
 
-	canMergeRelease, err := m.canMergeReleaseVersion(base, username)
+	canMergeRelease, inRelease, err := m.canMergeReleaseVersion(base, username)
 	if err != nil {
 		util.Error(err)
 		return false
@@ -65,12 +65,15 @@ func (m *merge) havePermission(username string, pr *github.PullRequest) bool {
 		return false
 	}
 
-	havePermission := m.ifInAllowList(username)
-	if !havePermission {
-		msg := fmt.Sprintf(noAccessComment, username)
-		util.Error(m.provider.CommentOnGithub(pr.GetNumber(), msg))
+	if !inRelease {
+		havePermission := m.ifInAllowList(username)
+		if !havePermission {
+			msg := fmt.Sprintf(noAccessComment, username)
+			util.Error(m.provider.CommentOnGithub(pr.GetNumber(), msg))
+		}
+		return havePermission
 	}
-	return havePermission
+	return true
 }
 
 func (m *merge) ProcessIssueCommentEvent(event *github.IssueCommentEvent) {

--- a/pkg/providers/merge/requests.go
+++ b/pkg/providers/merge/requests.go
@@ -110,14 +110,14 @@ func (m *merge) getReleaseMembers(base string) ([]*ReleaseMember, error) {
 	return releaseMembers, nil
 }
 
-func (m *merge) canMergeReleaseVersion(base, user string) (bool, error) {
+func (m *merge) canMergeReleaseVersion(base, user string) (bool, bool, error) {
 	var (
 		errMsg = "can merge release version"
 		now    = time.Now()
 	)
 	releaseVersions, err := m.getReleaseVersions(base)
 	if err != nil {
-		return false, errors.Wrap(err, errMsg)
+		return false, false, errors.Wrap(err, errMsg)
 	}
 	var releaseVersion *ReleaseVersion
 	for _, r := range releaseVersions {
@@ -129,20 +129,20 @@ func (m *merge) canMergeReleaseVersion(base, user string) (bool, error) {
 		}
 	}
 	if releaseVersion == nil {
-		return true, nil
+		return true, false, nil
 	}
 	// this branch's release version is in progress
 	// check out if the user has permission to merge it
 	members, err := m.getReleaseMembers(base)
 	if err != nil {
-		return false, errors.Wrap(err, errMsg)
+		return false, true, errors.Wrap(err, errMsg)
 	}
 	for _, m := range members {
 		if m.User == user {
-			return true, nil
+			return true, true, nil
 		}
 	}
-	return false, nil
+	return false, true, nil
 }
 
 func (m *merge) needUpdateBranch(pr *github.PullRequest) (bool, error) {


### PR DESCRIPTION
Signed-off-by: you06 <you1474600@gmail.com>

During releasement, memebers who can merge to release branch should not be forbidden by common release branch protect.