### PR TITLE
Support require lgtm label

### DIFF
--- a/pkg/operator/db.go
+++ b/pkg/operator/db.go
@@ -128,7 +128,7 @@ func (o *Operator) HasPermissionToPRWithLables(owner, repo string, labels []*git
 		if member.Level == ROLE_MAMINTAINER || member.Level == ROLE_PMC {
 			return nil // the PMC or maintainer can do anything
 		}
-		if legallRoles[member.Level] == true {
+		if legallRoles[member.Level] {
 			canEditSigs[member.SigID] = true
 		}
 	}
@@ -159,7 +159,7 @@ func (o *Operator) HasPermissionToPRWithLables(owner, repo string, labels []*git
 		sig_infos = append(sig_infos, fmt.Sprintf("[%s](%s)([slack](%s))", sig.SigName, sig.SigUrl, sig.Channel))
 	}
 
-	errMsg := fmt.Sprintf("You are not a %s for the related sigs:%s.", strings.Join(roles, " or "), strings.Join(sig_infos, ","))
+	errMsg := fmt.Sprintf("See the corresponding SIG page for more information. Related SIGs: %s.", strings.Join(sig_infos, ","))
 	return errors.New(errMsg)
 }
 

--- a/pkg/providers/approve/event.go
+++ b/pkg/providers/approve/event.go
@@ -108,7 +108,7 @@ func (a *Approve) ProcessIssueCommentEvent(event *github.IssueCommentEvent) {
 
 func (a *Approve) createApprove(senderID, prAuthorID string, pullNumber int, labels []*github.Label) {
 
-	comment := fmt.Sprintf("@%s,Thanks for your review.", senderID)
+	comment := "" //fmt.Sprintf("@%s,Thanks for your review.", senderID)""
 	defer func() {
 		log.Info(a.owner, a.repo, pullNumber, comment)
 		if err := a.opr.CommentOnGithub(a.owner, a.repo, pullNumber, comment); err != nil {
@@ -117,18 +117,15 @@ func (a *Approve) createApprove(senderID, prAuthorID string, pullNumber int, lab
 	}()
 
 	if senderID == prAuthorID {
-		msg := fmt.Sprintf(noAccessComment, senderID)
-		comment = fmt.Sprintf("%s you are the author.", msg)
+		comment = fmt.Sprintf("@%s Oops. LGTM is restricted to reviewers.", senderID)
 		return
 	}
 	alreadyExist, err := a.addLGTMRecord(senderID, pullNumber, labels)
 	if alreadyExist {
-		comment = ""
 		return
 	}
 	if err != nil {
-		msg := fmt.Sprintf(noAccessComment, senderID)
-		comment = fmt.Sprintf("%s %s", msg, err)
+		comment = fmt.Sprintf("%s", err)
 		util.Error(err)
 		return
 	}

--- a/pkg/providers/approve/request.go
+++ b/pkg/providers/approve/request.go
@@ -46,6 +46,7 @@ func (a *Approve) addLGTMRecord(login string, pullNumber int, labels []*github.L
 	}
 	err = a.opr.HasPermissionToPRWithLables(a.owner, a.repo, labels, login, operator.REVIEW_ROLES)
 	if err != nil {
+		err = fmt.Errorf("@%s,Thanks for your review. However, LGTM is restricted to Reviewers or higher roles.%s", login, err)
 		return
 	}
 	err = txn.Save(&record).Error

--- a/pkg/providers/merge/event.go
+++ b/pkg/providers/merge/event.go
@@ -45,8 +45,8 @@ func (m *merge) havePermission(username string, pr *github.PullRequest) bool {
 		}
 		err := m.CanMergeToMaster(pr.GetNumber(), pr.Labels, username)
 		if err != nil {
-			msg := fmt.Sprintf(noAccessComment, username)
-			msg = fmt.Sprintf("%s %s", msg, err)
+			// msg := fmt.Sprintf(noAccessComment, username)
+			msg := fmt.Sprintf("%s", err)
 			util.Error(m.opr.CommentOnGithub(m.owner, m.repo, pr.GetNumber(), msg))
 			return false
 		} else {

--- a/pkg/providers/merge/sig_permission.go
+++ b/pkg/providers/merge/sig_permission.go
@@ -13,6 +13,7 @@ import (
 func (m *merge) CanMergeToMaster(pullNumber int, labels []*github.Label, userName string) error {
 	err := m.opr.HasPermissionToPRWithLables(m.owner, m.repo, labels, userName, operator.MERGE_ROLES)
 	if err != nil {
+		err = fmt.Errorf("@%s Oops! auto merge is restricted to Committers of the SIG.%s", userName, err)
 		return err
 	}
 	lgtmNum, err := m.opr.GetLGTMNumForPR(m.owner, m.repo, pullNumber)
@@ -22,7 +23,7 @@ func (m *merge) CanMergeToMaster(pullNumber int, labels []*github.Label, userNam
 	}
 	needLGTMNum := m.opr.GetNumberOFLGTMByLable(m.repo, labels)
 	if lgtmNum < needLGTMNum {
-		return fmt.Errorf("The number of `LGTM` for this PR is %v while it needs %v at least", lgtmNum, needLGTMNum)
+		return fmt.Errorf("@%s Oops! This PR requires at least %v LGTMs to merge. The current number of `LGTM` is %v.", userName, needLGTMNum, lgtmNum)
 	}
 	return nil
 }


### PR DESCRIPTION
When bot receive a /merge command, it will check if the number of LGTM is enough. This PR will first check the PR's label. when a pr has a label like Require-LGT${number}, the ${number} is the min number of LGTM this pr required 