### PR TITLE
use comments to manage reviewers for PR

### DIFF
--- a/bot/bot.go
+++ b/bot/bot.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pingcap-incubator/cherry-bot/pkg/providers/assign"
 	autoUpdate "github.com/pingcap-incubator/cherry-bot/pkg/providers/auto-update"
 	"github.com/pingcap-incubator/cherry-bot/pkg/providers/cherry"
+	"github.com/pingcap-incubator/cherry-bot/pkg/providers/community"
 	"github.com/pingcap-incubator/cherry-bot/pkg/providers/contributor"
 	fileWatcher "github.com/pingcap-incubator/cherry-bot/pkg/providers/file-watcher"
 	notify "github.com/pingcap-incubator/cherry-bot/pkg/providers/issue-notify"
@@ -45,6 +46,7 @@ type Middleware struct {
 	FileWatcher      *fileWatcher.Watcher
 	Assign           *assign.Assign
 	AddLabel         *addLabel.Label
+	community        *community.CommunityCmd
 }
 
 type bot struct {
@@ -83,6 +85,7 @@ func InitBot(repo *config.RepoConfig, opr *operator.Operator) Bot {
 			label:            label.Init(repo, opr),
 			Prlimit:          prlimit.Init(repo, opr),
 			Merge:            merge.Init(repo, opr),
+			community:        community.Init(repo, opr),
 			IssueRedeliver:   issueRedeliver.Init(repo, opr),
 			PullStatus:       pullstatus.Init(repo, opr),
 			AutoUpdate:       autoUpdate.Init(repo, opr),

--- a/bot/webhook.go
+++ b/bot/webhook.go
@@ -79,6 +79,7 @@ func (b *bot) processIssueCommentEvent(event *github.IssueCommentEvent) {
 	if b.cfg.CherryPick {
 		b.Middleware.cherry.ProcessIssueCommentEvent(event)
 	}
+	b.Middleware.community.ProcessIssueCommentEvent(event)
 
 	if b.cfg.Merge {
 		b.Middleware.Merge.ProcessIssueCommentEvent(event)
@@ -96,10 +97,6 @@ func (b *bot) processIssueCommentEvent(event *github.IssueCommentEvent) {
 	if b.cfg.IssueSlackNotice {
 		b.Middleware.Notify.ProcessIssueCommentEvent(event)
 	}
-
-	// if b.cfg.PullApprove {
-	// 	b.Middleware.Approve.ProcessIssueCommentEvent(event)
-	// }
 
 	if b.cfg.AutoUpdate {
 		b.Middleware.AutoUpdate.ProcessIssueCommentEvent(event)

--- a/pkg/providers/add-label/label.go
+++ b/pkg/providers/add-label/label.go
@@ -6,23 +6,21 @@ import (
 )
 
 type Label struct {
-	owner   string
-	repo    string
-	ready   bool
-	approve bool
-	opr     *operator.Operator
-	cfg     *config.RepoConfig
+	owner string
+	repo  string
+	ready bool
+	opr   *operator.Operator
+	cfg   *config.RepoConfig
 }
 
 // Init create cherry pick middleware instance
 func Init(repo *config.RepoConfig, opr *operator.Operator) *Label {
 	n := Label{
-		owner:   repo.Owner,
-		repo:    repo.Repo,
-		ready:   false,
-		approve: repo.PullApprove,
-		cfg:     repo,
-		opr:     opr,
+		owner: repo.Owner,
+		repo:  repo.Repo,
+		ready: false,
+		cfg:   repo,
+		opr:   opr,
 	}
 	return &n
 }

--- a/pkg/providers/approve/approve.go
+++ b/pkg/providers/approve/approve.go
@@ -27,6 +27,6 @@ func Init(repo *config.RepoConfig, opr *operator.Operator) *Approve {
 	return &n
 }
 
-func (c *Approve) Ready() {
-	c.ready = true
-}
+// func (c *Approve) Ready() {
+// 	c.ready = true
+// }

--- a/pkg/providers/community/event.go
+++ b/pkg/providers/community/event.go
@@ -1,0 +1,54 @@
+package community
+
+import (
+	"github.com/google/go-github/v32/github"
+	"github.com/ngaut/log"
+	"github.com/pingcap-incubator/cherry-bot/config"
+	"github.com/pingcap-incubator/cherry-bot/pkg/operator"
+)
+
+type CommunityCmd struct {
+	owner string
+	repo  string
+	ready bool
+	opr   *operator.Operator
+	cfg   *config.RepoConfig
+}
+
+// Init create cherry pick middleware instance
+func Init(repo *config.RepoConfig, opr *operator.Operator) *CommunityCmd {
+	n := CommunityCmd{
+		owner: repo.Owner,
+		repo:  repo.Repo,
+		ready: false,
+		cfg:   repo,
+		opr:   opr,
+	}
+	return &n
+}
+
+func (c *CommunityCmd) Ready() {
+	c.ready = true
+}
+
+func (c *CommunityCmd) ProcessIssueCommentEvent(event *github.IssueCommentEvent) {
+	if event.GetAction() != "created" {
+		return
+	}
+	if err := c.processComment(event, event.Comment.GetBody()); err != nil {
+		log.Error("process community command failed", event.Comment.GetBody(), err)
+	} else {
+		log.Info("process community command success", event.Comment.GetBody())
+	}
+}
+
+func (c *CommunityCmd) processComment(event *github.IssueCommentEvent, comment string) error {
+	pr := event.GetIssue()
+	if pr.GetPullRequestLinks() != nil {
+		err := c.ptal(pr.GetNumber(), comment)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/providers/community/ptal.go
+++ b/pkg/providers/community/ptal.go
@@ -1,0 +1,46 @@
+package community
+
+import (
+	"context"
+	"strings"
+
+	"github.com/google/go-github/v32/github"
+	"github.com/ngaut/log"
+)
+
+const (
+	CC_CMD    = "/cc"
+	CC_CANCEL = "/uncc"
+)
+
+func (c *CommunityCmd) ptal(pullNumber int, comment string) error {
+	cc := strings.HasPrefix(comment, CC_CMD)
+	if cc {
+		comment = strings.TrimPrefix(comment, CC_CMD)
+	} else if strings.HasPrefix(comment, CC_CANCEL) {
+		comment = strings.TrimPrefix(comment, CC_CANCEL)
+	} else {
+		return nil
+	}
+	log.Info(cc, comment)
+	reviewers := []string{}
+	for _, login := range strings.Split(comment, ",") {
+		user := strings.TrimSpace(login)
+		user = strings.TrimPrefix(user, "@")
+		reviewers = append(reviewers, user)
+	}
+	reviewers_request := github.ReviewersRequest{
+		Reviewers: reviewers,
+	}
+	var res *github.Response
+	var err error
+	if cc {
+		_, res, err = c.opr.Github.PullRequests.RequestReviewers(context.Background(), c.owner, c.repo, pullNumber, reviewers_request)
+	} else {
+		res, err = c.opr.Github.PullRequests.RemoveReviewers(context.Background(), c.owner, c.repo, pullNumber, reviewers_request)
+	}
+	if err != nil {
+		log.Error(comment, "failed with", err, res, reviewers)
+	}
+	return nil
+}


### PR DESCRIPTION
Signed-off-by: shirly <AndreMouche@126.com>

<!-- Thank you for contributing to Cherry Bot! -->

### What problem does this PR solve?

support the following command:
- set reviewers to a pr:
/cc @you06,@lonng 
- remove the current reviewers from a pr
/uncc @you06 @lonng 


### Release note <!-- bugfixes or new feature need a release note -->
support to use comments to manager the reviewers for a PR
- <!-- Please write a release note here to describe the change you made when it is released to the users of Cherry Bot. If your PR doesn't involve any change to Cherry Bot(like test enhancements...), you can write `No release note`. -->