### PR TITLE
use /assign,/unassign to assign or unassign members

### DIFF
--- a/pkg/providers/assign/event.go
+++ b/pkg/providers/assign/event.go
@@ -2,15 +2,18 @@ package assign
 
 import (
 	"context"
+	"strings"
+
 	"github.com/google/go-github/v32/github"
+	"github.com/ngaut/log"
 	"github.com/pingcap-incubator/cherry-bot/util"
 	"github.com/pkg/errors"
-	"strings"
 )
 
 const (
 	assignCommand       = "/assign"
 	assignCancelCommand = "/assign cancel"
+	unAssignCommand     = "/unassign"
 )
 
 func (assign *Assign) ProcessIssueCommentEvent(event *github.IssueCommentEvent) {
@@ -23,32 +26,39 @@ func (assign *Assign) ProcessIssueCommentEvent(event *github.IssueCommentEvent) 
 		util.Error(err)
 		comment = "Assign failed."
 	}
-	if err := assign.addGithubComment(event.GetIssue().GetNumber(), comment); err != nil {
+	if err := assign.opr.CommentOnGithub(assign.owner, assign.repo, event.GetIssue().GetNumber(), comment); err != nil {
 		util.Error(err)
 	}
 }
 
-func (assign *Assign) do(event *github.IssueCommentEvent, opType string) (err error) {
-	assignees := []string{event.GetComment().GetUser().GetLogin()}
-	switch opType {
-	case assignCommand:
-		_, _, err = assign.opr.Github.Issues.AddAssignees(context.Background(), assign.owner, assign.repo,
+func (a *Assign) do(event *github.IssueCommentEvent, comment string) (err error) {
+	assign := strings.HasPrefix(comment, assignCommand)
+	if assign {
+		comment = strings.TrimPrefix(comment, assignCommand)
+	} else if strings.HasPrefix(comment, unAssignCommand) {
+		comment = strings.TrimPrefix(comment, unAssignCommand)
+	} else if strings.HasPrefix(comment, assignCancelCommand) {
+		comment = strings.TrimPrefix(comment, assignCancelCommand)
+	} else {
+		return nil
+	}
+	log.Info(assign, comment)
+	assignees := []string{}
+	for _, login := range strings.Split(comment, ",") {
+		user := strings.TrimSpace(login)
+		user = strings.TrimPrefix(user, "@")
+		assignees = append(assignees, user)
+	}
+	if len(assignees) == 0 {
+		assignees = []string{event.GetComment().GetUser().GetLogin()}
+	}
+	// TODO:check login's permission
+	if assign {
+		_, _, err = a.opr.Github.Issues.AddAssignees(context.Background(), a.owner, a.repo,
 			event.GetIssue().GetNumber(), assignees)
-	case assignCancelCommand:
-		_, _, err = assign.opr.Github.Issues.RemoveAssignees(context.Background(), assign.owner, assign.repo,
+	} else {
+		_, _, err = a.opr.Github.Issues.RemoveAssignees(context.Background(), a.owner, a.repo,
 			event.GetIssue().GetNumber(), assignees)
 	}
 	return errors.Wrap(err, "send assign")
-}
-
-func (assign *Assign) addGithubComment(pullNumber int, commentBody string) error {
-	if commentBody == "" {
-		return nil
-	}
-	comment := &github.IssueComment{
-		Body: &commentBody,
-	}
-	_, _, err := assign.opr.Github.Issues.CreateComment(context.Background(),
-		assign.owner, assign.repo, pullNumber, comment)
-	return errors.Wrap(err, "add github comment")
 }


### PR DESCRIPTION
Signed-off-by: shirly <AndreMouche@126.com>

<!-- Thank you for contributing to Cherry Bot! -->

### What problem does this PR solve?

Now people can use `assign` or `unassign` to assign members to an issue or PR

### What is changed and how it works?

What's Changed:

How it Works:

example to assign members:
`/assign XXX,XXX`

unassign members:
`/unassign XXX,XXX`