### PR TITLE
merge: fix extra message for auto merge

### DIFF
--- a/pkg/providers/merge/requests.go
+++ b/pkg/providers/merge/requests.go
@@ -196,6 +196,9 @@ func (m *merge) getMergeMessage(ID int) (string, error) {
 			}
 		}
 	}
+	if len(signedOffs) == 0 {
+		return " ", nil
+	}
 	return strings.Join(signedOffs, "\n"), nil
 }
 


### PR DESCRIPTION
Signed-off-by: you06 <you1474600@gmail.com>

<!-- Thank you for contributing to Cherry Bot! -->

### What problem does this PR solve?

Since go-github changed it's behavior, empty commit message will be considered as asking for a default commit message, this brings non-sense commit messages, this change add a workaround for it.

Problem Summary:

### What is changed and how it works?

What's Changed:

Leave a space when there are no signoff messages.

How it Works:

GitHub will trim this space.

### Release note <!-- bugfixes or new feature need a release note -->

- `No release note`