### PR TITLE
assign: do not add empty login name

### DIFF
--- a/pkg/providers/assign/event.go
+++ b/pkg/providers/assign/event.go
@@ -47,7 +47,9 @@ func (a *Assign) do(event *github.IssueCommentEvent, comment string) (err error)
 	for _, login := range strings.Split(comment, ",") {
 		user := strings.TrimSpace(login)
 		user = strings.TrimPrefix(user, "@")
-		assignees = append(assignees, user)
+		if user != "" {
+			assignees = append(assignees, user)
+		}
 	}
 	if len(assignees) == 0 {
 		assignees = []string{event.GetComment().GetUser().GetLogin()}


### PR DESCRIPTION
Signed-off-by: you06 <you1474600@gmail.com>

<!-- Thank you for contributing to Cherry Bot! -->

### What problem does this PR solve?

Fix a bug of assign issue.

Problem Summary:

### What is changed and how it works?

How it Works:

Check before add an assignee to avoid empty username.

### Release note <!-- bugfixes or new feature need a release note -->

- `No release note`