### PR TITLE
cherry: fix empty commit handle

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -130,6 +130,7 @@ github.com/google/go-github/v31 v31.0.0 h1:JJUxlP9lFK+ziXKimTCprajMApV1ecWD4NB6C
 github.com/google/go-github/v31 v31.0.0/go.mod h1:NQPZol8/1sMoWYGN2yaALIBytu17gAWfhbweiEed3pM=
 github.com/google/go-github/v32 v32.0.0 h1:q74KVb22spUq0U5HqZ9VCYqQz8YRuOtL/39ZnfwO+NM=
 github.com/google/go-github/v32 v32.0.0/go.mod h1:rIEpZD9CTDQwDK9GDrtMTycQNA4JU3qBsCizh3q2WCI=
+github.com/google/go-github/v32 v32.1.0 h1:GWkQOdXqviCPx7Q7Fj+KyPoGm4SwHRh8rheoPhd27II=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=

--- a/pkg/providers/cherry/request.go
+++ b/pkg/providers/cherry/request.go
@@ -329,7 +329,7 @@ func (cherry *cherry) prepareCherryPick(pr *github.PullRequest, target string) (
 				return errors.Wrap(err, message)
 			}
 			if out, err := do(dir, "git", "commit", "-s", "-m", commitMessage); err != nil {
-				if !strings.Contains(out, "nothing to commit, working directory clean") {
+				if !strings.Contains(out, "nothing to commit") {
 					message = "git commit failed"
 					return errors.Wrap(err, message)
 				}


### PR DESCRIPTION
Signed-off-by: you06 <you1474600@gmail.com>

<!-- Thank you for contributing to Cherry Bot! -->

### What problem does this PR solve?

Git changed its output for empty commit, this PR's change should handle it correctly.

### Release note <!-- bugfixes or new feature need a release note -->

- No release note