### PR TITLE
[Fail] providers/merge: allow any members to trigger /merge if a PR which targets to a release branch is approved

### DIFF
--- a/pkg/providers/merge/requests.go
+++ b/pkg/providers/merge/requests.go
@@ -133,15 +133,10 @@ func (m *merge) canMergeReleaseVersion(base, user string) (bool, bool, error) {
 	}
 	// this branch's release version is in progress
 	// check out if the user has permission to merge it
-	members, err := m.getReleaseMembers(base)
-	if err != nil {
-		return false, true, errors.Wrap(err, errMsg)
+	if m.opr.Member.IfMember(user) {
+		return true, true, nil
 	}
-	for _, m := range members {
-		if m.User == user {
-			return true, true, nil
-		}
-	}
+
 	return false, true, nil
 }
 

--- a/pkg/providers/merge/requests.go
+++ b/pkg/providers/merge/requests.go
@@ -99,17 +99,6 @@ func (m *merge) getReleaseVersions(base string) ([]*ReleaseVersion, error) {
 	return releaseVersions, nil
 }
 
-func (m *merge) getReleaseMembers(base string) ([]*ReleaseMember, error) {
-	var releaseMembers []*ReleaseMember
-	if err := m.opr.DB.Where("owner = ? and repo = ? and branch = ?", m.owner, m.repo,
-		base).Find(&releaseMembers).Error; err != nil && !gorm.IsRecordNotFoundError(err) {
-		return nil, errors.Wrap(err, "get release members from DB")
-	} else if gorm.IsRecordNotFoundError(err) {
-		return nil, nil
-	}
-	return releaseMembers, nil
-}
-
 func (m *merge) canMergeReleaseVersion(base, user string) (bool, bool, error) {
 	var (
 		errMsg = "can merge release version"


### PR DESCRIPTION
Signed-off-by: hexilee <i@hexilee.me>

<!-- Thank you for contributing to Cherry Bot! -->

### What problem does this PR solve?

Issue Number: close #53 <!-- REMOVE this line if no issue to close -->

Problem Summary:

If a PR which targets to a release branch is approved by an authorized member. Any other members but not only authorized members can trigger `/merge`.

### What is changed and how it works?

What's Changed:
- `Merge.canMergeReleaseVersion`

How it Works:

Replace the owner list with the member list.

### Release note <!-- bugfixes or new feature need a release note -->

- <!-- Please write a release note here to describe the change you made when it is released to the users of Cherry Bot. If your PR doesn't involve any change to Cherry Bot(like test enhancements...), you can write `No release note`. -->