### PR TITLE
fix release workflow

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -95,12 +95,12 @@ type RepoConfig struct {
 	PrLimitLabel     string
 	ContributorLabel string
 	// merge config
-	Merge                    bool   `toml:"auto-merge"`
-	CanMergeLabel            string `toml:"can-merge-label"`
-	ReleaseMaintainerControl bool   `toml:"release-maintainer-control"`
-	ReleaseLGTMNeed          int    `toml:"release-lgtm-need"`
-	SignedOffMessage         bool   `toml:"signed-off-message"`
-	MergeSIGControl          bool   `toml:"merge-sig-control"`
+	Merge                bool   `toml:"auto-merge"`
+	CanMergeLabel        string `toml:"can-merge-label"`
+	ReleaseAccessControl bool   `toml:"release-access-control"`
+	ReleaseLGTMNeed      int    `toml:"release-lgtm-need"`
+	SignedOffMessage     bool   `toml:"signed-off-message"`
+	MergeSIGControl      bool   `toml:"merge-sig-control"`
 	// issue redeliver
 	IssueRedeliver bool         `toml:"issue-redeliver"`
 	Redeliver      []*Redeliver `toml:"redeliver"`

--- a/config/config.go
+++ b/config/config.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	defaultReleaseLGTMNeed = 2
+	defaultReleaseLGTMNeed = 1
 )
 
 // Config is cherry picker config struct
@@ -95,11 +95,12 @@ type RepoConfig struct {
 	PrLimitLabel     string
 	ContributorLabel string
 	// merge config
-	Merge                bool   `toml:"auto-merge"`
-	CanMergeLabel        string `toml:"can-merge-label"`
-	ReleaseAccessControl bool   `toml:"release-access-control"`
-	SignedOffMessage     bool   `toml:"signed-off-message"`
-	MergeSIGControl      bool   `toml:"merge-sig-control"`
+	Merge                    bool   `toml:"auto-merge"`
+	CanMergeLabel            string `toml:"can-merge-label"`
+	ReleaseMaintainerControl bool   `toml:"release-maintainer-control"`
+	ReleaseLGTMNeed          int    `toml:"release-lgtm-need"`
+	SignedOffMessage         bool   `toml:"signed-off-message"`
+	MergeSIGControl          bool   `toml:"merge-sig-control"`
 	// issue redeliver
 	IssueRedeliver bool         `toml:"issue-redeliver"`
 	Redeliver      []*Redeliver `toml:"redeliver"`
@@ -122,9 +123,7 @@ type RepoConfig struct {
 	IssueSlackNoticeChannel string `toml:"issue-slack-notice-channel"`
 	IssueSlackNoticeNotify  string `toml:"issue-slack-notice-notify"`
 	// approve
-	PullApprove           bool `toml:"pull-approve"`
-	ReleaseApproveControl bool `toml:"release-approve-control"`
-	ReleaseLGTMNeed       int  `toml:"release-lgtm-need"`
+	PullApprove bool `toml:"pull-approve"`
 	// contributor
 	NotifyNewContributorPR bool `toml:"notify-new-contributor-pr"`
 	// watch file change

--- a/pkg/operator/db.go
+++ b/pkg/operator/db.go
@@ -41,6 +41,14 @@ type AutoMergeAllowName struct {
 	CreatedAt time.Time `gorm:"created_at"`
 }
 
+type LgtmRecord struct {
+	Owner      string `gorm:"column:owner"`
+	Repo       string `gorm:"column:repo"`
+	PullNumber int    `gorm:"column:pull_number"`
+	Github     string `gorm:"column:github"`
+	Score      int    `gorm:"column:score"`
+}
+
 const (
 	ROLE_PMC         = "pmc"
 	ROLE_MAMINTAINER = "maintainer"
@@ -185,10 +193,16 @@ func (o *Operator) GetLGTMNumForPR(owner, repo string, pullNumber int) (num int,
 }
 
 func (o *Operator) GetLGTMReviewers(owner, repo string, pullNumber int) (reviewers []string, err error) {
+	var records []*LgtmRecord
+
 	err = o.DB.Table("lgtm_records").
 		Where("score>0 and repo=? and owner=? and pull_number=?", repo, owner, pullNumber).
-		Select(&reviewers, "github").
+		Find(&records).
 		Error
+
+	for _, record := range records {
+		reviewers = append(reviewers, (*record).Github)
+	}
 	return
 }
 

--- a/pkg/providers/approve/event.go
+++ b/pkg/providers/approve/event.go
@@ -137,7 +137,6 @@ func (a *Approve) ProcessIssueCommentEvent(event *github.IssueCommentEvent) {
 }
 
 func (a *Approve) createApprove(senderID, prAuthorID, base string, pullNumber int, labels []*github.Label) {
-
 	comment := "" //fmt.Sprintf("@%s,Thanks for your review.", senderID)""
 	defer func() {
 		log.Info(a.owner, a.repo, pullNumber, comment)
@@ -149,15 +148,12 @@ func (a *Approve) createApprove(senderID, prAuthorID, base string, pullNumber in
 		comment = fmt.Sprintf("@%s Sorry, You can’t approve your own PR.", senderID)
 		return
 	}
-	if base == master {
-		if err := a.opr.HasPermissionToPRWithLables(a.owner, a.repo, labels, senderID, operator.REVIEW_ROLES); err != nil {
-			comment = fmt.Sprintf("@%s, Thanks for your review. The bot only counts LGTMs from Reviewers and higher roles, but you're still welcome to leave your comments. %s", senderID, err)
-			return
-		}
-	} else if a.cfg.ReleaseApproveControl && strings.HasPrefix(base, releasePrefix) && !a.opr.IsAllowed(a.owner, a.repo, senderID) {
-		comment = fmt.Sprintf(noAccessComment, senderID)
+
+	if err := a.opr.HasPermissionToPRWithLables(a.owner, a.repo, labels, senderID, operator.REVIEW_ROLES); err != nil {
+		comment = fmt.Sprintf("@%s, Thanks for your review. The bot only counts LGTMs from Reviewers and higher roles, but you're still welcome to leave your comments. %s", senderID, err)
 		return
 	}
+
 	alreadyExist, err := a.addLGTMRecord(senderID, pullNumber, labels)
 	if alreadyExist {
 		return

--- a/pkg/providers/merge/event.go
+++ b/pkg/providers/merge/event.go
@@ -47,7 +47,7 @@ func (m *merge) havePermission(username string, pr *github.PullRequest) (permiss
 	}()
 
 	if username != m.opr.Config.Github.Bot && m.cfg.MergeSIGControl {
-		if base == "master" || (strings.HasPrefix(base, "release") && !m.cfg.ReleaseMaintainerControl) {
+		if base == "master" || (strings.HasPrefix(base, "release") && !m.cfg.ReleaseAccessControl) {
 			if err := m.SIGAutoMergeCheck(pr.Labels, username); err != nil {
 				msg = err.Error()
 				return
@@ -93,7 +93,7 @@ func (m *merge) havePermission(username string, pr *github.PullRequest) (permiss
 			}
 		}
 
-		if m.cfg.ReleaseMaintainerControl {
+		if m.cfg.ReleaseAccessControl {
 			reviewers, err := m.opr.GetLGTMReviewers(m.owner, m.repo, *pr.Number)
 			if err != nil {
 				util.Error(err)

--- a/pkg/providers/merge/event.go
+++ b/pkg/providers/merge/event.go
@@ -13,11 +13,12 @@ import (
 )
 
 const (
-	autoMergeCommand      = "/run-auto-merge"
-	autoMergeAlias        = "/merge"
-	unMergeCommand        = "/unmerge"
-	noAccessComment       = "Sorry @%s, you don't have permission to trigger auto merge event on this branch."
-	versionReleaseComment = "The version releasement is in progress."
+	autoMergeCommand                    = "/run-auto-merge"
+	autoMergeAlias                      = "/merge"
+	unMergeCommand                      = "/unmerge"
+	noAccessComment                     = "Sorry @%s, you don't have permission to trigger auto merge event on this branch."
+	needReleaseMaintainerApproveComment = "Sorry @%s, this branch cannot be merged without an approval of release maintainers"
+	versionReleaseComment               = "The version releasement is in progress."
 )
 
 func (m *merge) ProcessPullRequestEvent(event *github.PullRequestEvent) {
@@ -45,32 +46,33 @@ func (m *merge) havePermission(username string, pr *github.PullRequest) (permiss
 		}
 	}()
 
-	if m.owner != "chaos-mesh" && base == "master" {
-		if username != m.opr.Config.Github.Bot && m.cfg.MergeSIGControl {
+	if username != m.opr.Config.Github.Bot && m.cfg.MergeSIGControl {
+		if base == "master" || (strings.HasPrefix(base, "release") && !m.cfg.ReleaseMaintainerControl) {
+			if err := m.SIGAutoMergeCheck(pr.Labels, username); err != nil {
+				msg = err.Error()
+				return
+			}
+		}
+		if base == "master" {
 			if err := m.CanMergeToMaster(pr.GetNumber(), pr.Labels, username); err != nil {
 				msg = err.Error()
 				return
 			}
 		}
-	} else if strings.HasPrefix(base, "release") {
+	}
+
+	if strings.HasPrefix(base, "release") {
 		if err := m.CanMergeToRelease(pr.GetNumber(), username); err != nil {
 			msg = err.Error()
 			return
 		}
-
 		currentReleaseVersion, err := m.currentReleaseVersion(base)
 		if err != nil {
 			util.Error(err)
 			return
 		}
 
-		if currentReleaseVersion == nil {
-			havePermission := m.ifInAllowList(username)
-			if !havePermission {
-				msg = fmt.Sprintf(noAccessComment, username)
-				return
-			}
-		} else {
+		if currentReleaseVersion != nil {
 			// this branch's release version is in progress
 			// check out if the user has permission to merge it
 			members, err := m.getReleaseMembers(base)
@@ -90,7 +92,21 @@ func (m *merge) havePermission(username string, pr *github.PullRequest) (permiss
 				return
 			}
 		}
+
+		if m.cfg.ReleaseMaintainerControl {
+			reviewers, err := m.opr.GetLGTMReviewers(m.owner, m.repo, *pr.Number)
+			if err != nil {
+				util.Error(err)
+				return
+			}
+
+			if !m.opr.IsAllowed(m.owner, m.repo, reviewers...) {
+				msg = fmt.Sprintf(needReleaseMaintainerApproveComment, username)
+				return
+			}
+		}
 	}
+
 	return true
 }
 

--- a/pkg/providers/merge/permission.go
+++ b/pkg/providers/merge/permission.go
@@ -22,12 +22,15 @@ func (m *merge) checkLGTM(pullNumber, needLGTM int, userName string) error {
 	return nil
 }
 
-func (m *merge) CanMergeToMaster(pullNumber int, labels []*github.Label, userName string) error {
+func (m *merge) SIGAutoMergeCheck(labels []*github.Label, userName string) error {
 	err := m.opr.HasPermissionToPRWithLables(m.owner, m.repo, labels, userName, operator.MERGE_ROLES)
 	if err != nil {
 		err = fmt.Errorf("@%s Oops! auto merge is restricted to Committers of the SIG.%s", userName, err)
-		return err
 	}
+	return err
+}
+
+func (m *merge) CanMergeToMaster(pullNumber int, labels []*github.Label, userName string) error {
 	return m.checkLGTM(pullNumber, m.opr.GetNumberOFLGTMByLable(m.repo, labels), userName)
 }
 

--- a/pkg/providers/merge/whitelist.go
+++ b/pkg/providers/merge/whitelist.go
@@ -26,9 +26,5 @@ func (m *merge) RemoveAllowList(username string) error {
 }
 
 func (m *merge) ifInAllowList(username string) bool {
-	if !m.cfg.ReleaseAccessControl {
-		return true
-	}
-
 	return m.opr.IsAllowed(m.owner, m.repo, username)
 }


### PR DESCRIPTION
<!-- Thank you for contributing to Cherry Bot! -->

### What problem does this PR solve?

Problem Summary:
- only release maintainers can approve PR on release-* branch

### What is changed and how it works?

What's Changed: 

- Allow all reviewers to aprove PR on release-* branch.
- Use `RepoConfig.ReleaseAccessControl` to enable release maintainers checking.

### Release note <!-- bugfixes or new feature need a release note -->

- <!-- Please write a release note here to describe the change you made when it is released to the users of Cherry Bot. If your PR doesn't involve any change to Cherry Bot(like test enhancements...), you can write `No release note`. -->