### PR TITLE
enable PR limitation and take cherry-pick into count

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -90,10 +90,10 @@ type RepoConfig struct {
 	// pr limit config
 	PrLimit          bool   `toml:"pr-limit"`
 	MaxPrOpened      int    `toml:"max-pr-opened"`
-	PrLimitMode      string `toml: "pr-limit-mode"`
-	PrLimitOrgs      string `toml: "pr-limit-orgs"`
-	PrLimitLabel     string `toml: "pr-limit-label"`
-	ContributorLabel string `toml: "contributor-label"`
+	PrLimitMode      string `toml:"pr-limit-mode"`
+	PrLimitOrgs      string `toml:"pr-limit-orgs"`
+	PrLimitLabel     string `toml:"pr-limit-label"`
+	ContributorLabel string `toml:"contributor-label"`
 	// merge config
 	Merge                bool   `toml:"auto-merge"`
 	CanMergeLabel        string `toml:"can-merge-label"`

--- a/config/config.go
+++ b/config/config.go
@@ -86,14 +86,14 @@ type RepoConfig struct {
 	LabelCheckChannel   string `toml:"label-check-channel"`
 	DefaultChecker      string `toml:"default-checker"`
 	InviteCollaborator  bool   `toml:"invite-collaborator"`
-	// TODO: remove it
+
 	// pr limit config
-	PrLimit          bool
-	MaxPrOpened      int
-	PrLimitMode      string
-	PrLimitOrgs      string
-	PrLimitLabel     string
-	ContributorLabel string
+	PrLimit          bool   `toml:"pr-limit"`
+	MaxPrOpened      int    `toml:"max-pr-opened"`
+	PrLimitMode      string `toml: "pr-limit-mode"`
+	PrLimitOrgs      string `toml: "pr-limit-orgs"`
+	PrLimitLabel     string `toml: "pr-limit-label"`
+	ContributorLabel string `toml: "contributor-label"`
 	// merge config
 	Merge                bool   `toml:"auto-merge"`
 	CanMergeLabel        string `toml:"can-merge-label"`

--- a/pkg/providers/prlimit/request.go
+++ b/pkg/providers/prlimit/request.go
@@ -30,9 +30,9 @@ func (p *prLimit) canApprove(login string) (bool, error) {
 	return true, nil
 }
 
-func (p *prLimit) commentPr(openedPr *github.PullRequest, openedPrSlice []*github.PullRequest) error {
-	commentBody := fmt.Sprintf("Thanks for your PR.\nThis PR will be closed by bot because you already had %d opened PRs",
-		len(openedPrSlice))
+func (p *prLimit) commentPr(openedPr *github.PullRequest, openedPrSlice, cherryPickSlice []*github.PullRequest) error {
+	commentBody := fmt.Sprintf("Thanks for your PR.\nThis PR will be closed by bot because you already had %d opened PRs and %d cherry-pick PRs",
+		len(openedPrSlice), len(cherryPickSlice))
 	commentBody += ", close or merge them before submitting a new one.\n"
 
 	var prLinkSlice []string
@@ -40,6 +40,16 @@ func (p *prLimit) commentPr(openedPr *github.PullRequest, openedPrSlice []*githu
 		prLinkSlice = append(prLinkSlice, fmt.Sprintf("https://github.com/%s/%s/pull/%d",
 			p.owner, p.repo, *pr.Number))
 	}
+	commentBody += "opened PRs: "
+	commentBody += strings.Join(prLinkSlice[:], " , ")
+
+	prLinkSlice = []string{}
+	for _, pr := range cherryPickSlice {
+		prLinkSlice = append(prLinkSlice, fmt.Sprintf("https://github.com/%s/%s/pull/%d",
+			p.owner, p.repo, *pr.Number))
+	}
+
+	commentBody += "cherry-pick PRs: "
 	commentBody += strings.Join(prLinkSlice[:], " , ")
 
 	comment := &github.IssueComment{


### PR DESCRIPTION
<!-- Thank you for contributing to Cherry Bot! -->

### What problem does this PR solve?

Problem Summary:

Sometimes we need to limit the max PRs opened of some members.
### What is changed and how it works?

What's Changed:

How it Works:

### Release note <!-- bugfixes or new feature need a release note -->

- <!-- Please write a release note here to describe the change you made when it is released to the users of Cherry Bot. If your PR doesn't involve any change to Cherry Bot(like test enhancements...), you can write `No release note`. -->