### PR TITLE
add new table `test_jobs`; save failed test jobs of auto merges

### DIFF
--- a/bot.sql
+++ b/bot.sql
@@ -91,6 +91,33 @@ LOCK TABLES `auto_merges` WRITE;
 UNLOCK TABLES;
 
 --
+-- Table structure for table `test_jobs`
+--
+
+DROP TABLE IF EXISTS `test_jobs`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `test_jobs` (
+  `id` int(11) NOT NULL,
+  `merge_job_id` int(11) NOT NULL,
+  `state` varchar(31) NOT NULL,
+  `description` varchar(1023) COLLATE utf8_bin NOT NULL,
+  `target_url` varchar(1023) NOT NULL,
+  `context` varchar(1023) NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `test_jobs`
+--
+
+LOCK TABLES `test_jobs` WRITE;
+/*!40000 ALTER TABLE `test_jobs` DISABLE KEYS */;
+/*!40000 ALTER TABLE `autotest_jobs_merges` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
 -- Table structure for table `block_names`
 --
 

--- a/pkg/providers/merge/worker.go
+++ b/pkg/providers/merge/worker.go
@@ -171,6 +171,9 @@ func (m *merge) checkPR(mergeJob *AutoMerge) {
 	if *status.State == "failure" || *status.State == "error" {
 		success = false
 		util.Println("Tests failed in statuses", status)
+		if err := m.saveFailTestJob(mergeJob, status); err != nil {
+			util.Println("fail to save test jobs: ", err)
+		}
 	}
 	if *status.State == "pending" {
 		return


### PR DESCRIPTION
Signed-off-by: hexilee <i@hexilee.me>

<!-- Thank you for contributing to Cherry Bot! -->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

Failed test jobs will be overridden after a new test job successing, so we should save them in database.

### What is changed and how it works?

What's Changed:

How it Works:

### Release note <!-- bugfixes or new feature need a release note -->

- <!-- Please write a release note here to describe the change you made when it is released to the users of Cherry Bot. If your PR doesn't involve any change to Cherry Bot(like test enhancements...), you can write `No release note`. -->